### PR TITLE
Fix PHP 8 installation failure

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -103,7 +103,7 @@ class Controller extends BaseController
         }
     }
 
-    public function postDelete($group = null, $key = null)
+    public function postDelete($group, $key)
     {
         if(!in_array($group, $this->manager->getConfig('exclude_groups')) && $this->manager->getConfig('delete_enabled')) {
             Translation::where('group', $group)->where('key', $key)->delete();

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -103,7 +103,7 @@ class Controller extends BaseController
         }
     }
 
-    public function postDelete($group = null, $key)
+    public function postDelete($group = null, $key = null)
     {
         if(!in_array($group, $this->manager->getConfig('exclude_groups')) && $this->manager->getConfig('delete_enabled')) {
             Translation::where('group', $group)->where('key', $key)->delete();


### PR DESCRIPTION
When using PHP 8 the translation manager fails to install because of the new changes in the language
In PHP 8 parameters without a default value are required to be BEFORE optional parameters.

We do not want to change the position of the params because that could break the application. So setting $key to null is a possible fix, not the best but...